### PR TITLE
Update Jenkins build script for new Makefile

### DIFF
--- a/.jenkins-valgrind.sh
+++ b/.jenkins-valgrind.sh
@@ -7,5 +7,5 @@ done
 cd *-*/
 
 sh configure --disable-dependency-tracking --enable-debug-build
-trap 'cat src/test-suite.log' EXIT
+trap 'cat test-suite.log' EXIT
 make -k LOG_COMPILER='$(SHELL) $(top_srcdir)/../.jenkins-log.sh' check


### PR DESCRIPTION
The test-suite.log file is now in the top directory due to the Makefile structure change in #68.
