### PR TITLE
Update Travis build script for new Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
 script:
  - sh -x .travis.sh --run
 after_failure:
- - cat src/test-suite.log
+ - cat test-suite.log


### PR DESCRIPTION
The test-suite.log file is now in the top directory due to the Makefile structure change in #68.
