### PR TITLE
Fix Maybe::operator= template definition

### DIFF
--- a/src/common/Maybe.hh
+++ b/src/common/Maybe.hh
@@ -196,7 +196,11 @@ public:
      * @tparam U the type of the assigned object.
      * @param v the assigned object.
      */
-    template<typename U>
+    template<
+            typename U,
+            typename = typename std::enable_if<
+                    std::is_constructible<T, U &&>::value &&
+                    std::is_assignable<T, U &&>::value>::type>
     Maybe &operator=(U &&v)
             noexcept(std::is_nothrow_constructible<T, U &&>::value &&
                     std::is_nothrow_assignable<T, U &&>::value) {

--- a/src/common/MaybeTest.cc
+++ b/src/common/MaybeTest.cc
@@ -258,6 +258,9 @@ TEST_CASE("Maybe assignment") {
     Maybe<long> m1;
     const Maybe<long> m2(123L);
 
+    m1 = m1;
+    CHECK_FALSE(m1.hasValue());
+
     m1 = m2;
     REQUIRE(m1.hasValue());
     CHECK(m1.value() == 123L);


### PR DESCRIPTION
The assignment operator template is now enabled only if the operand is constructible & assignable to the target contained object, so that the template is not misused for maybe-to-maybe assignment.
