### PR TITLE
Fix SignalNumberSetImpl constructors

### DIFF
--- a/src/os/ApiImpl.cc
+++ b/src/os/ApiImpl.cc
@@ -147,14 +147,14 @@ private:
 
 public:
 
-    SignalNumberSetImpl() : mSet(sesh_osapi_sigset_new()) {
+    SignalNumberSetImpl() : SignalNumberSet(), mSet(sesh_osapi_sigset_new()) {
         if (mSet == nullptr)
             throw std::bad_alloc();
         sesh_osapi_sigemptyset(mSet.get());
     }
 
     SignalNumberSetImpl(const SignalNumberSetImpl &other) :
-            mSet(sesh_osapi_sigset_new()) {
+            SignalNumberSet(other), mSet(sesh_osapi_sigset_new()) {
         if (mSet == nullptr)
             throw std::bad_alloc();
         sesh_osapi_sigcopyset(mSet.get(), other.get());


### PR DESCRIPTION
This commit fixes the copy constructor of SignalNumberSetImpl which was wrongly calling the default constructor of SignalNumberSet.
