### PR TITLE
Fix compilation error in AwaiterTimeoutTest

### DIFF
--- a/src/os/event/AwaiterTimeoutTest.cc
+++ b/src/os/event/AwaiterTimeoutTest.cc
@@ -93,7 +93,7 @@ void checkEmpty(
         const FileDescriptorSet *fds,
         FileDescriptor::Value fdBound,
         const std::string &info) {
-    checkEqual(fds, {}, fdBound, info);
+    checkEqual(fds, std::set<FileDescriptor::Value>{}, fdBound, info);
 }
 
 TEST_CASE_METHOD(


### PR DESCRIPTION
The std::set default constructor is declared "explicit," so it must be called with the explicit type name. I missed to notice this error because libstdc++ 4.8.2 wrongly declares the constructor non-explicit.
