### PR TITLE
More efficient empty shared pointer construction

### DIFF
--- a/src/language/parser/OperatorParser.cc
+++ b/src/language/parser/OperatorParser.cc
@@ -19,10 +19,7 @@
 #include "OperatorParser.hh"
 
 #include <memory>
-#include "common/Nop.hh"
 #include "language/parser/Operator.hh"
-
-using sesh::common::Nop;
 
 namespace sesh {
 namespace language {
@@ -30,10 +27,8 @@ namespace parser {
 
 OperatorParser createOperatorParser(
         Environment &e, LineContinuationTreatment lct) {
-    return OperatorParser(
-            e,
-            std::shared_ptr<OperatorParser::Trie>(&Operator::TRIE, Nop()),
-            lct);
+    using P = std::shared_ptr<OperatorParser::Trie>;
+    return OperatorParser(e, P(P(), &Operator::TRIE), lct);
 }
 
 } // namespace parser


### PR DESCRIPTION
Passing a nop deleter to the shared_ptr constructor would allocate an internal resource manager object. That unnecessary allocation can be avoided by constructing from another empty pointer.
