### PR TITLE
Make Jenkins test runner scripts independent

### DIFF
--- a/.jenkins-archive.sh
+++ b/.jenkins-archive.sh
@@ -1,0 +1,4 @@
+set -Ceu
+
+# TODO support submodules
+exec git archive -o .workspace.tar.gz HEAD

--- a/.jenkins-dist.sh
+++ b/.jenkins-dist.sh
@@ -1,5 +1,0 @@
-set -eu
-
-autoreconf -i
-sh configure
-make dist-gzip

--- a/.jenkins-distcheck.sh
+++ b/.jenkins-distcheck.sh
@@ -1,10 +1,5 @@
 set -eu
 
-for tarball in *-*.tar.gz
-do
-  gzip -dc "$tarball" | tar -x -f -
-done
-cd *-*/
-
+autoreconf -i
 sh configure
 make -k VERBOSE=1 distcheck

--- a/.jenkins-doxygen.sh
+++ b/.jenkins-doxygen.sh
@@ -1,10 +1,5 @@
 set -eu
 
-for tarball in *-*.tar.gz
-do
-  gzip -dc "$tarball" | tar -x -f -
-done
-cd *-*/
-
+autoreconf -i
 sh configure
 make -k doxygen

--- a/.jenkins-valgrind.sh
+++ b/.jenkins-valgrind.sh
@@ -1,11 +1,5 @@
 set -eu
 
-for tarball in *-*.tar.gz
-do
-  gzip -dc "$tarball" | tar -x -f -
-done
-cd *-*/
-
+autoreconf -i
 sh configure --disable-dependency-tracking --enable-debug-build
-make -k LOG_COMPILER='$(SHELL) $(top_srcdir)/../.jenkins-log.sh' VERBOSE=1 \
-  check
+make -k LOG_COMPILER='$(SHELL) $(top_srcdir)/.jenkins-log.sh' VERBOSE=1 check


### PR DESCRIPTION
Previously, the following test runner scripts were depending on existence of the sesh-*.tar.gz archive file:
- .jenkins-distcheck.sh
- .jenkins-doxygen.sh
- .jenkins-valgrind.sh

After this commit, those script no longer depend on the archive file. They are now expected to be run directly in the Git workspace. It is now easier to debug the test script in a local environment.

The .jenkins-dist.sh script is removed in favor of the new .jenkins-archive.sh script.
