### PR TITLE
Use is_assignable with lvalue reference

### DIFF
--- a/src/common/Maybe.hh
+++ b/src/common/Maybe.hh
@@ -202,10 +202,10 @@ public:
             typename U,
             typename = typename std::enable_if<
                     std::is_constructible<T, U &&>::value &&
-                    std::is_assignable<T, U &&>::value>::type>
+                    std::is_assignable<T &, U &&>::value>::type>
     Maybe &operator=(U &&v)
             noexcept(std::is_nothrow_constructible<T, U &&>::value &&
-                    std::is_nothrow_assignable<T, U &&>::value) {
+                    std::is_nothrow_assignable<T &, U &&>::value) {
         if (hasValue())
             value() = std::forward<U>(v);
         else

--- a/src/common/Variant.hh
+++ b/src/common/Variant.hh
@@ -303,7 +303,7 @@ public:
             typename V = typename std::remove_const<
                     typename std::remove_reference<T>::type>::type>
     void operator()(T &&v) const
-            noexcept(std::is_nothrow_assignable<V, T &&>::value) {
+            noexcept(std::is_nothrow_assignable<V &, T &&>::value) {
         mTarget.template value<V>() = std::forward<T>(v);
     }
 
@@ -905,7 +905,7 @@ public:
      * @see #reset
      */
     template<typename U, typename V = typename std::decay<U>::type>
-    void assign(U &&v) noexcept(std::is_nothrow_assignable<V, U &&>::value) {
+    void assign(U &&v) noexcept(std::is_nothrow_assignable<V &, U &&>::value) {
         if (tag() == tag<V>())
             value<V>() = std::forward<U>(v);
         else


### PR DESCRIPTION
Normally, the std::is_assignable class template should be used with an l-value reference type to get desired results.
